### PR TITLE
Filter the NOT supported MIMEs in Assets list. Albums or favorite

### DIFF
--- a/custom_components/immich/hub.py
+++ b/custom_components/immich/hub.py
@@ -99,12 +99,6 @@ class ImmichHub:
                         _LOGGER.error("Error from API: status=%d", response.status)
                         return None
 
-                    if response.content_type not in _ALLOWED_MIME_TYPES:
-                        _LOGGER.error(
-                            "MIME type is not supported: %s", response.content_type
-                        )
-                        return None
-
                     return await response.read()
         except aiohttp.ClientError as exception:
             _LOGGER.error("Error connecting to the API: %s", exception)
@@ -128,7 +122,7 @@ class ImmichHub:
                     assets: list[dict] = favorites["assets"]["items"]
 
                     filtered_assets: list[dict] = [
-                        asset for asset in assets if asset["type"] == "IMAGE"
+                        asset for asset in assets if (asset["type"] == "IMAGE") and (asset["originalMimeType"] in _ALLOWED_MIME_TYPES) 
                     ]
 
                     return filtered_assets
@@ -173,7 +167,7 @@ class ImmichHub:
                     assets: list[dict] = album_info["assets"]
 
                     filtered_assets: list[dict] = [
-                        asset for asset in assets if asset["type"] == "IMAGE"
+                        asset for asset in assets if (asset["type"] == "IMAGE") and (asset["originalMimeType"] in _ALLOWED_MIME_TYPES)
                     ]
 
                     return filtered_assets


### PR DESCRIPTION
The HASS log as to many record when there are many not suported MIME photos in a album or as favorite. This is because the photos are not filtered in the moment of creating the album asset list.
As solution I propose to move the filter to 'list_favorite_images' and 'list_album_images' using 'originalMimeType' variable.

Test with an album tht has 100% of heic photos.

Before the change: every second
![image](https://github.com/user-attachments/assets/e370df15-ab97-4a77-9843-892f842c3fe3)

After the change: every 5 minutes
![image](https://github.com/user-attachments/assets/67f550d9-37c2-4b69-ba72-19975e806037)

