### PR TITLE
Adding `any_image` entity

### DIFF
--- a/custom_components/immich/image.py
+++ b/custom_components/immich/image.py
@@ -35,7 +35,7 @@ async def async_setup_entry(
     )
 
     # Create entity for random favorite image
-    async_add_entities([ImmichImageFavorite(hass, hub)])
+    async_add_entities([ImmichImageFavorite(hass, hub), ImmichImageAll(hass, hub)])
 
     # Create entities for random image from each watched album
     watched_albums = config_entry.options.get(CONF_WATCHED_ALBUMS, [])

--- a/custom_components/immich/image.py
+++ b/custom_components/immich/image.py
@@ -158,6 +158,17 @@ class ImmichImageFavorite(BaseImmichImage):
         return [image["id"] for image in await self.hub.list_favorite_images()]
 
 
+class ImmichImageAll(BaseImmichImage):
+    """Image entity for Immich that displays a random image from all available images"""
+
+    _attr_unique_id = "any_image"
+    _attr_name = "Immich: Random image"
+
+    async def _refresh_available_asset_ids(self) -> list[str] | None:
+        """Refresh the list of available asset IDs."""
+        return [image["id"] for image in await self.hub.list_all_images()]
+
+
 class ImmichImageAlbum(BaseImmichImage):
     """Image entity for Immich that displays a random image from a specific album."""
 


### PR DESCRIPTION
# Add `any_image` entity

## Code changes

- Add `list_all_images` method to `ImmichHub`
- Add new `ImmichImageAll` class in `image.py`
- Insert `ImmichImageAll` object into list of default entities, alongside random favourite

Includes a small clean-up of only querying the api for image filetypes in `list_favourite_images`: <https://immich.app/docs/api/search-metadata>

## Testing

Tested locally on my own HA instance:
![image](https://github.com/user-attachments/assets/c02d8267-6c5c-431d-956b-3ecbadc7049f)
(image is not in any albums)

## Possible extras

Maybe could add config to enable/disable both any image and random favourite entities - I haven't done this yet because I'm very new to HA integration development and wanted to start small :P

Closes #6 
